### PR TITLE
[MOBI-2737] Disable offers by-default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [3.2.1] - 2025-24-03
+### Changed
+- Default option for `showSurveys()` method set to `false`
+- Disable the offers for `showNativeSurvey` by default
+- Updated native iOS SDK to 2.5.1
+- Updated native Android SDK to 2.5.1
+
+### Fixed:
+- Android deprecated API `setStatusBarColor`
+
 ## [3.2.0] - 2024-12-06
 
 ### Added

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -71,5 +71,5 @@ repositories {
 dependencies {
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'
-    implementation 'com.github.inbrainai:sdk-android:[2.5.0, 2.6.0)'
+    implementation 'com.github.inbrainai:sdk-android:[2.5.1, 2.6.0)'
 }

--- a/inbrain-surveys.podspec
+++ b/inbrain-surveys.podspec
@@ -20,6 +20,6 @@ Pod::Spec.new do |s|
   s.source_files = "ios/*.{h,m,swift}"
 
   s.dependency "React"
-  s.dependency 'InBrainSurveys', '~> 2.5.0'
+  s.dependency 'InBrainSurveys', '~> 2.5.1'
 
 end

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "inbrain-surveys",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "inbrain-surveys",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.20.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "inbrain-surveys",
   "title": "Inbrain Survey",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "In-App monetization via surveys, powered by inBrain.ai.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/InBrain.tsx
+++ b/src/InBrain.tsx
@@ -118,7 +118,7 @@ const checkSurveysAvailable = () =>
  * Opens the InBrain survey wall
  * @param option Indicates which feature is available at the dashboard: Surveys, Offers, or both
  */
-const openWall = (option: InBrainWallOption = InBrainWallOption.all) =>
+const openWall = (option: InBrainWallOption = InBrainWallOption.surveys) =>
   wrapPromise<void>(() => InBrainSurveys.openWall(option));
 
 /**
@@ -145,7 +145,7 @@ const getNativeSurveys = (filter?: InBrainSurveyFilter) =>
 const showNativeSurvey = (
   id: string,
   searchId: string,
-  offersEnabled: boolean = true
+  offersEnabled: boolean = false
 ) =>
   wrapPromise<void>(() =>
     InBrainSurveys.showNativeSurvey(id, searchId, offersEnabled)
@@ -175,7 +175,7 @@ const getCurrencySale = () =>
  * @deprecated Use openWall() instead
  */
 const showSurveys = () =>
-  wrapPromise<void>(() => openWall(InBrainWallOption.all));
+  wrapPromise<void>(() => openWall(InBrainWallOption.surveys));
 
 // ----------------------- Unsupported -------------------------------
 


### PR DESCRIPTION
- Disable `offers` by default;
- Update iOS and Android SDKs to 2.5.1+;
- Fixed deprecated API `setStatusBarColor`